### PR TITLE
Modal styling

### DIFF
--- a/front-end/src/components/Settings/GestureBox.js
+++ b/front-end/src/components/Settings/GestureBox.js
@@ -13,7 +13,7 @@ export default function GestureBox({name, newSetting, redNum}) {
   const innerGrid = {
     flex: 1,
     textAlign: "center",
-    borderRight: "1px solid white",
+   borderRight: "1px solid #96B4F2",
     color: "white",
     background: theBackground,
   }

--- a/front-end/src/components/Settings/GestureBox.js
+++ b/front-end/src/components/Settings/GestureBox.js
@@ -31,7 +31,7 @@ export default function GestureBox({name, newSetting, redNum}) {
     newSetting(name)
   }
 
-  if(name) {
+  if(!Number.isInteger(name)) {
     return (
       <div onClick={handleClick} style={innerGrid}>
         <div style={gestures}><img style={imgFormat} src={name}></img></div>

--- a/front-end/src/components/Settings/GestureBox.js
+++ b/front-end/src/components/Settings/GestureBox.js
@@ -9,6 +9,7 @@ export default function GestureBox({name, newSetting, redNum}) {
     theBackground ="#081a2d"
   }
 
+
   const innerGrid = {
     flex: 1,
     textAlign: "center",
@@ -30,9 +31,18 @@ export default function GestureBox({name, newSetting, redNum}) {
     newSetting(name)
   }
 
-  return (
-    <div onClick={handleClick} style={innerGrid}>
-      <div style={gestures}><img style={imgFormat} src={name}></img></div>
-    </div>
-  )
+  if(name) {
+    return (
+      <div onClick={handleClick} style={innerGrid}>
+        <div style={gestures}><img style={imgFormat} src={name}></img></div>
+      </div>
+    )
+  } else {
+    return (
+      <div onClick={handleClick} style={innerGrid}>
+        <div style={gestures}>-</div>
+      </div>
+    )
+  }
+
 }

--- a/front-end/src/components/Settings/HandButtons.js
+++ b/front-end/src/components/Settings/HandButtons.js
@@ -101,11 +101,13 @@ export default function HandButtons({dat, changeSettings}) {
             },
             content: {
               backgroundColor: "#081a2d",
+              border: "3px white solid",
               borderRadius: "25px",
-              height: "42vh",
-              width: "42vh",
+              height: "44vh",
+              width: "44vh",
               margin: "30vh auto",
-              padding: 0
+              padding: 0,
+              overflow: "hidden"
             }
           }}
         >

--- a/front-end/src/components/Settings/HandButtons.js
+++ b/front-end/src/components/Settings/HandButtons.js
@@ -30,6 +30,7 @@ export default function HandButtons({dat, changeSettings}) {
   function newSetting(newGesture) {
     changeSettings(dat[2] - 1, newGesture)
     setRedNum(newGesture)
+    console.log(newGesture);
     //setTimeout(function(){ setShowModal(false) }, 500);
   }
 
@@ -105,8 +106,8 @@ export default function HandButtons({dat, changeSettings}) {
             </div>
             <div style={row}>
               <GestureBox name={rocknroll} newSetting={newSetting} redNum={redNum}/>
-              <GestureBox name={8} newSetting={newSetting} redNum={redNum}/>
-              <GestureBox name={9} newSetting={newSetting} redNum={redNum}/>
+              <GestureBox name={0} newSetting={newSetting} redNum={redNum}/>
+              <GestureBox name={0} newSetting={newSetting} redNum={redNum}/>
             </div>
           </div>
 

--- a/front-end/src/components/Settings/HandButtons.js
+++ b/front-end/src/components/Settings/HandButtons.js
@@ -30,8 +30,6 @@ export default function HandButtons({dat, changeSettings}) {
   function newSetting(newGesture) {
     changeSettings(dat[2] - 1, newGesture)
     setRedNum(newGesture)
-    console.log(newGesture);
-    //setTimeout(function(){ setShowModal(false) }, 500);
   }
 
   const btnStyle = {
@@ -48,7 +46,8 @@ export default function HandButtons({dat, changeSettings}) {
     flexDirection: "column",
     padding: 0,
     margin: 0,
-    height: "100%"
+    height: "100%",
+    borderRadius: "25px"
   }
 
   const row = {
@@ -57,14 +56,6 @@ export default function HandButtons({dat, changeSettings}) {
     display: "flex",
     flexDirection: "row"
   }
-
-  const innerGrid = {
-    flex: 1,
-    textAlign: "center",
-    borderRight: "1px solid white",
-    color: "white",
-  }
-
 
   const imgFormat = {
     width: "auto",
@@ -86,6 +77,7 @@ export default function HandButtons({dat, changeSettings}) {
             },
             content: {
               backgroundColor: "#081a2d",
+              borderRadius: "25px",
               height: "42vh",
               width: "42vh",
               margin: "30vh auto",

--- a/front-end/src/components/Settings/HandButtons.js
+++ b/front-end/src/components/Settings/HandButtons.js
@@ -54,7 +54,7 @@ export default function HandButtons({dat, changeSettings}) {
 
   const row = {
     flex: 1,
-    border: "1px solid white",
+    border: "1px solid #96B4F2",
     display: "flex",
     flexDirection: "row"
   }
@@ -101,7 +101,7 @@ export default function HandButtons({dat, changeSettings}) {
             },
             content: {
               backgroundColor: "#081a2d",
-              border: "3px white solid",
+              border: "3px #E1DDFC solid",
               borderRadius: "25px",
               height: "44vh",
               width: "44vh",

--- a/front-end/src/components/Settings/HandButtons.js
+++ b/front-end/src/components/Settings/HandButtons.js
@@ -106,8 +106,8 @@ export default function HandButtons({dat, changeSettings}) {
             </div>
             <div style={row}>
               <GestureBox name={rocknroll} newSetting={newSetting} redNum={redNum}/>
-              <GestureBox name={0} newSetting={newSetting} redNum={redNum}/>
-              <GestureBox name={0} newSetting={newSetting} redNum={redNum}/>
+              <GestureBox name={8} newSetting={newSetting} redNum={redNum}/>
+              <GestureBox name={9} newSetting={newSetting} redNum={redNum}/>
             </div>
           </div>
 

--- a/front-end/src/components/Settings/HandButtons.js
+++ b/front-end/src/components/Settings/HandButtons.js
@@ -19,6 +19,7 @@ export default function HandButtons({dat, changeSettings}) {
   function handleClick() {
     //if button clicked, outline border
     setBorderClr("1px solid white");
+    setRedNum(dat[1]);
     setShowModal(true);
   }
 

--- a/front-end/src/components/Settings/HandButtons.js
+++ b/front-end/src/components/Settings/HandButtons.js
@@ -90,13 +90,14 @@ export default function HandButtons({dat, changeSettings}) {
       {iconButton()}
         <Modal
           isOpen={showModal}
-          contentLabel="Minimal example"
+          contentLabel="Icon selector"
           onRequestClose={closeModal}
           ariaHideApp={false}
           style={{
             overlay: {
               margin: 0,
-              padding: 0
+              padding: 0,
+              backgroundColor: "rgba(145,209,255, 0.5)"
             },
             content: {
               backgroundColor: "#081a2d",

--- a/front-end/src/components/Settings/HandButtons.js
+++ b/front-end/src/components/Settings/HandButtons.js
@@ -16,6 +16,7 @@ export default function HandButtons({dat, changeSettings}) {
   const [redNum, setRedNum] = useState(-2);
 
 
+
   function handleClick() {
     //if button clicked, outline border
     setBorderClr("1px solid white");
@@ -63,9 +64,30 @@ export default function HandButtons({dat, changeSettings}) {
     height: "3vh"
   }
 
+  const dashStyle = {
+    color: "#afb0b2"
+
+  }
+
+
+  function iconButton() {
+    if (!Number.isInteger(dat[1])) {
+
+      return (  <button style={btnStyle} onClick={handleClick}> <img style={imgFormat} src={dat[1]}></img> </button>)
+    } else {
+
+      return (
+        <button style={btnStyle} onClick={handleClick}>
+          <h3 style={dashStyle}>---</h3>
+        </button>
+      )
+    }
+  }
+
+
   return (
     <div>
-      <button style={btnStyle} onClick={handleClick}> <img style={imgFormat} src={dat[1]}></img> </button>
+      {iconButton()}
         <Modal
           isOpen={showModal}
           contentLabel="Minimal example"

--- a/front-end/src/components/Settings/SideBar.js
+++ b/front-end/src/components/Settings/SideBar.js
@@ -20,10 +20,6 @@ export default function SideBar({btnClick}) {
     margin: "15vh 2.5vw",
   }
 
-  const cameraOptionStyle = {
-    margin: "15vh 3vw 0 0"
-  }
-
   return (
     <div>
       <div style={logoStyle}>


### PR DESCRIPTION
Fixed some bugs and improved the styling of the modal (the icon 'menu' that pops up when you hit a button on the settings page). 

I am thinking of going for a different approach on the modal where the formatting is not as grid dependent in order to easily be able to add or remove new icons when needed without having to completely rework the structure. It would also be cool to have a little swipper / slider button at the bottom of the modal to easily change between left and right hand.

![Modal](https://user-images.githubusercontent.com/40405324/119082976-bbc65d00-b9c4-11eb-9232-3b8e80366b13.PNG)
